### PR TITLE
Remove sliders and stabilize skeleton

### DIFF
--- a/Physics/GameViewController.swift
+++ b/Physics/GameViewController.swift
@@ -15,10 +15,6 @@ class GameViewController: NSViewController {
     var mtkView: MTKView!
     private var pauseBtn: NSButton!
     private var resetBtn: NSButton!
-    private var speedSlider: NSSlider!
-    private var muscleSlider: NSSlider!
-    private var gravitySlider: NSSlider!
-    private var dampingSlider: NSSlider!
     
     private var keysHeld = Set<UInt16>()
     
@@ -58,49 +54,6 @@ class GameViewController: NSViewController {
         pauseBtn = makeButton(title: "Pause",  action: #selector(togglePause), x: 10)
         resetBtn = makeButton(title: "Reset",  action: #selector(doReset),    x: 100)
         
-        speedSlider = NSSlider(value: 1.0,
-                               minValue: 0.1,
-                               maxValue: 2.0,
-                               target: self,
-                               action: #selector(speedChanged))
-        speedSlider.frame = CGRect(x: 200, y: view.bounds.height - 30,
-                                   width: 150, height: 20)
-        speedSlider.isContinuous = true
-        speedSlider.autoresizingMask = [.minYMargin, .maxXMargin]
-        view.addSubview(speedSlider)
-
-        muscleSlider = NSSlider(value: 0.5,
-                                minValue: 0.1,
-                                maxValue: 1.0,
-                                target: self,
-                                action: #selector(muscleChanged))
-        muscleSlider.frame = CGRect(x: 370, y: view.bounds.height - 30,
-                                    width: 150, height: 20)
-        muscleSlider.isContinuous = true
-        muscleSlider.autoresizingMask = [.minYMargin, .maxXMargin]
-        view.addSubview(muscleSlider)
-
-        gravitySlider = NSSlider(value: 1.0,
-                                 minValue: 0.1,
-                                 maxValue: 2.0,
-                                 target: self,
-                                 action: #selector(gravityChanged))
-        gravitySlider.frame = CGRect(x: 540, y: view.bounds.height - 30,
-                                     width: 150, height: 20)
-        gravitySlider.isContinuous = true
-        gravitySlider.autoresizingMask = [.minYMargin, .maxXMargin]
-        view.addSubview(gravitySlider)
-
-        dampingSlider = NSSlider(value: 0.98,
-                                 minValue: 0.90,
-                                 maxValue: 1.0,
-                                 target: self,
-                                 action: #selector(dampingChanged))
-        dampingSlider.frame = CGRect(x: 710, y: view.bounds.height - 30,
-                                     width: 150, height: 20)
-        dampingSlider.isContinuous = true
-        dampingSlider.autoresizingMask = [.minYMargin, .maxXMargin]
-        view.addSubview(dampingSlider)
     }
     
     // REPLACE: keyDown / keyUp to update set & forward to renderer
@@ -133,20 +86,4 @@ class GameViewController: NSViewController {
         renderer.resetSkeleton()
     }
     
-    // MARK: - Slider
-    @objc private func speedChanged() {
-        renderer.timeScale = Float(speedSlider.doubleValue)
-    }
-
-    @objc private func muscleChanged() {
-        renderer.muscleScale = Float(muscleSlider.doubleValue)
-    }
-
-    @objc private func gravityChanged() {
-        renderer.gravityScale = Float(gravitySlider.doubleValue)
-    }
-
-    @objc private func dampingChanged() {
-        renderer.damping = Float(dampingSlider.doubleValue)
-    }
 }

--- a/Physics/Renderer.swift
+++ b/Physics/Renderer.swift
@@ -29,9 +29,10 @@ final class Renderer: NSObject, MTKViewDelegate {
     private let boneVB       : MTLBuffer    // unit quad for limbs
     
     // ── Input / physics state ─────────────────────────────────────
-    var muscleScale: Float = 0.5   // live-tunable from UI
-    var gravityScale: Float = 1.0      // live-tunable from UI
-    var damping: Float = 0.98        // live‑tunable from UI
+    // Fixed simulation parameters (sliders removed)
+    var muscleScale: Float = 0.0
+    var gravityScale: Float = 1.0
+    var damping: Float = 0.98
     var debugEnabled = false       // toggled by “D”
     /// Toggle drawing the yellow muscles.  Disabled while we’re working on the skeleton.
     var showMuscles = false
@@ -39,7 +40,7 @@ final class Renderer: NSObject, MTKViewDelegate {
     private var lastTime : CFTimeInterval = 0
     private var debugFrames = 0   // print first 120 frames
     
-    private let groundY   : Float = -8.9         // top edge of the ground quad near bottom of view.
+    private let groundY   : Float = 0.0          // y‑position of the ground plane
     private var skel = Skeleton.twoLegs()
     var paused = false
     var timeScale: Float = 1.0
@@ -239,24 +240,7 @@ final class Renderer: NSObject, MTKViewDelegate {
     
     // MARK: ‑ Logic
     private func updateGame(dt: Float) {
-        // Map currently held keys to muscle contractions.  Arrow keys control
-        // the quadriceps/hamstrings of each leg.
-        let upArrow: UInt16    = 0x7E
-        let downArrow: UInt16  = 0x7D
-        let leftArrow: UInt16  = 0x7B
-        let rightArrow: UInt16 = 0x7C
-
-        let contractQuad  = keysHeld.contains(upArrow)
-        let contractHam   = keysHeld.contains(downArrow)
-        let contractQuadR = keysHeld.contains(rightArrow)
-        let contractHamR  = keysHeld.contains(leftArrow)
-
-        // Update dynamic rest lengths based on input
-        skel.applyUserInput(contractQuad: contractQuad,
-                            contractHam: contractHam,
-                            contractQuadR: contractQuadR,
-                            contractHamR: contractHamR,
-                            dt: dt)
+        // Muscle input temporarily disabled
 
         // Advance the simulation with the current parameters
         skel.step(dt: dt,

--- a/Physics/Skeleton.swift
+++ b/Physics/Skeleton.swift
@@ -40,7 +40,7 @@ final class Skeleton {
     // convenience factory: two mirrored legs hanging from a fixed pelvis
     static func twoLegs() -> Skeleton {
         // ── Key reference points ───────────────────────────────
-        let pelvis   = SIMD2<Float>(0, 0.5)        // body origin (fixed)
+        let pelvis   = SIMD2<Float>(0, 4.0)        // body origin (fixed)
         let spineLen : Float = 2.0                 // pelvis → chest
         let legSeg   : Float = 2.0                 // thigh / shin
         let armSeg   : Float = 1.4                 // shorter upper / lower arm
@@ -213,7 +213,7 @@ extension Skeleton {
               damping: Float = 0.98) {
 
         // ── Zero-velocity anchor for pelvis ───────────────────
-        let pelvis = SIMD2<Float>(0, 0.5)
+        let pelvis = SIMD2<Float>(0, 4.0)
         bones[0].pA = pelvis;  bones[0].prevPA = pelvis          // left thigh root
         if bones.count > 2 {
             bones[2].pA = pelvis;  bones[2].prevPA = pelvis      // right thigh root

--- a/README.md
+++ b/README.md
@@ -13,9 +13,5 @@ A lightweight Metal-based macOS playground that demonstrates a simple 2‑D ragd
 - **D** – toggle debug logging of bone positions.
 - **Pause** – pause or resume the simulation.
 - **Reset** – restore the skeleton to the initial pose.
-- **Speed Slider** – adjust simulation speed.
-- **Muscle Slider** – scale muscle contraction strength.
-- **Gravity Slider** – scale gravity strength.
-- **Damping Slider** – adjust damping applied to velocity.
 
 The application starts with a simple two‑legged skeleton standing on a ground plane. Use the controls to explore how the muscles and constraints interact.


### PR DESCRIPTION
## Summary
- remove slider UI from the macOS view controller
- use fixed physics parameters and disable muscle input
- align the skeleton to a ground plane at y=0

## Testing
- `swiftc -parse Physics/*.swift`